### PR TITLE
Fix comment block detection and handling per tap specification

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,6 @@ var COMMENT = 'COMMENT'
 var RESULT = 'RESULT'
 var TODO = 'TODO'
 
-var COMMENT_BLOCK_PADDING_SIZE = 2
-
 var REGEXES = {
   test: /^#\s+(.+)/,
   assertion: new RegExp('^(not )?ok\\b(?:(?:\\s+(\\d+))?(?:\\s+(?:(?:\\s*-\\s*)?(.*)))?)?'),
@@ -32,9 +30,11 @@ var REGEXES = {
   skip: /^(.*?)\s*#\s*SKIP\s+(.*)$/
 }
 
-var removeCommentBlockPadding = R.map(R.drop(COMMENT_BLOCK_PADDING_SIZE))
+var getBaseCommentPadding = R.compose(R.prop('length'), R.nth(1), R.match(/^(\s+)---/), R.nth(0))
+var removeCommentBlockPadding = R.converge(R.map, [R.converge(R.drop, [getBaseCommentPadding]), R.identity]);
 var parseYamlBlock = R.pipe(
   removeCommentBlockPadding,
+  R.slice(1, -1),
   R.join('\n'),
   jsYaml.safeLoad
 )
@@ -397,7 +397,7 @@ function isCommentBlockStart (line) {
     return false
   }
 
-  return line.indexOf('  ---') === 0
+  return line.match(/^\s+---/);
 }
 
 function isCommentBlockEnd (line) {
@@ -406,7 +406,7 @@ function isCommentBlockEnd (line) {
     return false
   }
 
-  return line.indexOf('  ...') === 0
+  return line.match(/^\s+\.\.\./);
 }
 
 function isAssertion (line) {

--- a/test/fixtures/yaml-indented-more.txt
+++ b/test/fixtures/yaml-indented-more.txt
@@ -1,0 +1,11 @@
+TAP version 13
+# test 1
+not ok 1 indented more than two spaces
+       ---
+         a: b
+       ...
+
+1..1
+# tests 1
+# pass  0
+# fail  1

--- a/test/observable.js
+++ b/test/observable.js
@@ -271,6 +271,22 @@ test('parses result values', function (t) {
   }
 })
 
+test('parses yaml indented more in failing assertions', function (t) {
+
+  t.plan(1)
+
+  return function (done) {
+
+    tapOut.observeStream(fixtureStream('yaml-indented-more')).failingAssertions$
+      .forEach(function (assertion) {
+
+        t.deepEqual(assertion.diagnostic, {
+          a: 'b'
+        }, 'parsed yaml block')
+      })
+  }
+})
+
 // Helpers
 
 function yamlTapStream () {
@@ -281,6 +297,11 @@ function yamlTapStream () {
 function basicTapStream () {
 
   return fs.createReadStream(__dirname + '/fixtures/basic.txt')
+}
+
+function fixtureStream (name) {
+
+  return fs.createReadStream(__dirname + '/fixtures/' + name + '.txt')
 }
 
 function filterTypeInObservable$ (stream, type) {

--- a/test/stream.js
+++ b/test/stream.js
@@ -261,6 +261,22 @@ test('parses result values', function (t) {
   }
 })
 
+test('parses yaml indented more in failing assertions', function (t) {
+
+  t.plan(1)
+
+  return function (done) {
+
+    tapOut.observeStream(fixtureStream('yaml-indented-more')).failingAssertions$
+      .forEach(function (assertion) {
+
+        t.deepEqual(assertion.diagnostic, {
+          a: 'b'
+        }, 'parsed yaml block')
+      })
+  }
+})
+
 // Helpers
 
 function yamlTapStream () {
@@ -271,6 +287,11 @@ function yamlTapStream () {
 function basicTapStream () {
 
   return fs.createReadStream(__dirname + '/fixtures/basic.txt')
+}
+
+function fixtureStream (name) {
+
+  return fs.createReadStream(__dirname + '/fixtures/' + name + '.txt')
 }
 
 function filterTypeInStream (stream, type) {


### PR DESCRIPTION
TAP Version 13 says that comment blocks can be indented with any number
of spaces. Changed detection regexes to match specification and added
detection to remove the correct number of spaces from each line in the
comment block. Removed the --- and ... lines as they're not valid YAML.

Fixes #8 